### PR TITLE
Fix: API Version Parsing Error

### DIFF
--- a/install-cursor-crostini.sh
+++ b/install-cursor-crostini.sh
@@ -66,7 +66,7 @@ get_latest_cursor_url() {
     
     # Get the latest version info from Cursor's official download API
     local download_info
-    download_info=$(curl -s "https://www.cursor.com/api/download?platform=linux-x64&releaseTrack=stable")
+    download_info=$(curl -sL "https://www.cursor.com/api/download?platform=linux-x64&releaseTrack=stable")
     
     if [[ -z "$download_info" ]]; then
         print_error "Failed to fetch latest version information from Cursor API"


### PR DESCRIPTION

This PR addresses an issue where ./install-cursor-crostini.sh fails to parse version information from the API response, resulting in an `[ERROR] Failed to parse version information from API response message.`

I've added an argument to handle this, ensuring the script can successfully fetch the latest Cursor version and complete the installation.