### PR TITLE
Update install-cursor-crostini.sh

### DIFF
--- a/install-cursor-crostini.sh
+++ b/install-cursor-crostini.sh
@@ -66,7 +66,7 @@ get_latest_cursor_url() {
     
     # Get the latest version info from Cursor's official download API
     local download_info
-    download_info=$(curl -s "https://www.cursor.com/api/download?platform=linux-x64&releaseTrack=stable")
+    download_info=$(curl -s "https://cursor.com/api/download?platform=linux-x64&releaseTrack=stable")
     
     if [[ -z "$download_info" ]]; then
         print_error "Failed to fetch latest version information from Cursor API"

--- a/install-cursor-crostini.sh
+++ b/install-cursor-crostini.sh
@@ -55,7 +55,8 @@ install_dependencies() {
     sudo apt update
     
     # Install FUSE and other dependencies required for AppImages
-    sudo apt install -y fuse libfuse2 wget curl
+    sudo apt install -y fuse libfuse2 wget curl libnss3-dev
+
     
     print_success "Dependencies installed successfully"
 }


### PR DESCRIPTION
Fix redirect error due to cursor removing www subdomain

There is another pending pull request for this issue, but believe this is the better fix.
Instead of blindly accepting any redirects, simply fixed the url.

Also a new dependency needed to run, added libnss3-dev